### PR TITLE
Use fully qualified path for rlua::UserData in UserData derive macro

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rlua-builders"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["Yan Soares Couto <yancouto@gmail.com>"]
 edition = "2018"
 license = "MIT"

--- a/rlua-builders-derive/src/lib.rs
+++ b/rlua-builders-derive/src/lib.rs
@@ -74,7 +74,7 @@ fn builder_for_fields(name: TokenStream2, fields: &Fields) -> TokenStream2 {
 
 fn function_struct_builder(name: Ident, builder: TokenStream2) -> TokenStream2 {
     quote! {
-        impl<'s> LuaBuilder<'s, rlua::Function<'s>> for #name {
+        impl<'s> ::rlua_builders::LuaBuilder<'s, rlua::Function<'s>> for #name {
             fn builder(ctx: rlua::Context<'s>) -> rlua::Result<rlua::Function<'s>> {
                 #builder
             }
@@ -84,7 +84,7 @@ fn function_struct_builder(name: Ident, builder: TokenStream2) -> TokenStream2 {
 
 fn self_struct_builder(name: Ident, builder: TokenStream2) -> TokenStream2 {
     quote! {
-        impl<'s> LuaBuilder<'s, Self> for #name {
+        impl<'s> ::rlua_builders::LuaBuilder<'s, Self> for #name {
             fn builder(ctx: rlua::Context<'s>) -> rlua::Result<Self> {
                 #builder
             }
@@ -115,7 +115,7 @@ fn enum_builder(name: Ident, de: DataEnum) -> TokenStream2 {
         .unzip();
 
     quote! {
-        impl<'s> LuaBuilder<'s, rlua::Table<'s>> for #name {
+        impl<'s> ::rlua_builders::LuaBuilder<'s, rlua::Table<'s>> for #name {
             fn builder(ctx: rlua::Context<'s>) -> rlua::Result<rlua::Table<'s>> {
                 let t = ctx.create_table()?;
                 #( t.set(stringify!(#names), #builders?)?; )*

--- a/rlua-builders-derive/src/lib.rs
+++ b/rlua-builders-derive/src/lib.rs
@@ -160,7 +160,7 @@ pub fn derive_user_data(input: TokenStream) -> TokenStream {
     let name = input.ident;
 
     let expanded = quote! {
-        impl UserData for #name {}
+        impl ::rlua::UserData for #name {}
     };
 
     TokenStream::from(expanded)

--- a/tests/success_tests.rs
+++ b/tests/success_tests.rs
@@ -1,4 +1,3 @@
-use rlua::UserData;
 use rlua_builders::*;
 
 #[test]


### PR DESCRIPTION
Hey, thanks for the crate!

When using #[derive(UserData)], I noticed that I had to add a use statement for rlua::UserData, so I made a slight modification that uses the fully qualified path for UserData in the derive macro. With this change, the user will no longer have to add a use statement and it means a name collision won't lead to incorrect generated code.

edit: Noticed a similar issue with the LuaBuilder derive macro and added a commit for that as well